### PR TITLE
release: update openclaw-lagoon-base to v2026.6.11_1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.6.10_8
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.6.11_1
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
This Pull Request updates the base image version of `openclaw-gateway` to `v2026.6.11_1` in `docker-compose.yml`.

- **Target Version:** `v2026.6.11_1`

This release fixes cron jobs (and device pairings / exec approvals / plugin state) being lost on every gateway restart: the boot entrypoint was deleting `state/openclaw.sqlite` — OpenClaw's canonical runtime store — as an NFS RollingUpdate lock workaround. It now only clears stale `-wal`/`-shm` lock sidecars. See amazeeio/openclaw-lagoon-base@f7895e05b651.

Please review the changes and merge to deploy.
