### PR TITLE
release: update openclaw-lagoon-base to v2026.6.11_3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.6.11_1
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.6.11_3
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
## Summary
Bump the base image pin from `v2026.6.11_1` to `v2026.6.11_3`.

This base revision brings:
- Default channel plugins baked into the image (seeded onto the volume at boot; no runtime npm-against-NFS storm).
- Webhooks bundled plugin enabled by default (`plugins.entries.webhooks.enabled = true`); users add their own routes per instance, preserved across redeploys.
- `gateway.trustedProxies` defaulted for the in-cluster Lagoon proxy.
- `gateway.controlUi.allowedOrigins` now unioned (UI-added origins survive redeploys).

## Verification
Base image `v2026.6.11_3` built and published successfully (all 5 default plugins seeded during build); see amazeeio/openclaw-lagoon-base tag v2026.6.11_3.