### PR TITLE
release: update openclaw-lagoon-base to v2026.7.1_1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.6.11_3
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.1_1
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Updates the base image to v2026.7.1_1 (OpenClaw core 2026.7.1 + enforced Slack replyToMode=first so replies always go into a thread).
