### PR TITLE
release: update openclaw-lagoon-base to v2026.7.1_2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.1_1
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.1_2
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Updates the base image to v2026.7.1_2: raises the Node heap limit to 4GB via --max-old-space-size=4096, fixing 'FATAL ERROR: Reached heap limit Allocation failed' crashes on instances that outgrow Node's ~2GB default heap cap.