### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.2_1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.1_2
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.2-beta.2_1
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Updates the base image to v2026.7.2-beta.2_1:

- Bumps OpenClaw core to 2026.7.2-beta.2, fixing the 2026.7.1 Memory Core legacy migration conflict that crash-loops gateways on startup (openclaw/openclaw#107133). Affected instances self-heal on deploy.
- Lowers the Node heap cap from 4GB to 3GB (--max-old-space-size=3072) so heap plus native memory stays within a 4Gi pod limit.