### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.2_2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.2-beta.2_1
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.2-beta.2_2
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Updates the base image to v2026.7.2-beta.2_2.

Fixes the deploy failure where a gateway with a configured-but-not-seeded plugin (e.g. a user-enabled brave plugin) crash-looped on startup: the build baked a root-owned /tmp/.npm cache, so the runtime plugin install under uid 10000 failed with EACCES and the gateway refused to report ready (progress deadline exceeded). The build now drops its /tmp caches so npm/node recreate them as the runtime user.

Core stays on 2026.7.2-beta.2 (unchanged from _1). Also hardens the base repo's auto-bump so it skips OpenClaw versions with no matching -browser image instead of breaking the build.