### PR TITLE
chore: switch openclaw-gateway service type to basic-single

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,5 @@ services:
     ports:
       - "3001:3000"
     labels:
-      lagoon.type: node-persistent
+      lagoon.type: basic-single
       lagoon.persistent: /home/.openclaw


### PR DESCRIPTION
## What

Switches the `openclaw-gateway` service from `node-persistent` (EFS/RWX) to [`basic-single`](https://docs.lagoon.sh/concepts-advanced/service-types/) (EBS/RWO). One-line label change.

Fixes #27.

## Why

OpenClaw stores all runtime state in embedded SQLite, and SQLite locking is unreliable on NFS: constant lock contention at runtime and a failed 2026.6 → 2026.7 upgrade (`database is locked`). WAL mode is unavailable on NFS. OpenClaw has no non-SQLite backend (openclaw/openclaw#1568), so the fix is at the storage layer: block storage makes SQLite locking local.

## What stays the same

- Service name `openclaw-gateway` → autogenerated route URLs are unchanged.
- `basic-single` exposes port 3000 by default, same as `node` — no port label needed.
- `lagoon.persistent: /home/.openclaw` is supported by `basic-single`.

## Behaviour changes

- Single replica, Recreate deploys → brief downtime on every deploy. This is by design: OpenClaw is a single-writer gateway; two replicas cannot share the same SQLite, and RWO prevents old/new pods overlapping on the volume during deploys (the original upgrade failure mode).
- `basic-single` does not support additional volumes — not used today.

## ⚠️ Do not merge until the fleet repoint is done

Existing projects have RWX PVCs whose access mode cannot change in place. All 185 existing projects must first have their git URL repointed to [`openclaw-lagoon-node`](https://github.com/amazeeio/openclaw-lagoon-node) (frozen copy). After merge, this repo only affects **newly created** projects, which get a fresh RWO volume. Existing instances are migrated separately per #27.

## Open question

- `lagoon.persistent.size`: not set, so new volumes get the Lagoon default (5Gi). EBS volumes are per-instance and annoying to grow fleet-wide later — should we set an explicit size? Needs a `du -sh /home/.openclaw` reading from a mature instance to decide.