### PR TITLE
feat: allow per-project base image pinning via OPENCLAW_BASE_TAG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
 
       - name: Update docker-compose.yml
         run: |
-          # Use yq to update the image tag for the openclaw-gateway service
-          yq -i '.services.openclaw-gateway.image = "ghcr.io/amazeeio/openclaw-lagoon-base:${{ github.event.inputs.version }}"' docker-compose.yml
+          # Use yq to update the default image tag for the openclaw-gateway service,
+          # preserving the OPENCLAW_BASE_TAG per-project override syntax.
+          yq -i '.services.openclaw-gateway.image = "ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-${{ github.event.inputs.version }}}"' docker-compose.yml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/validate-version.yml
+++ b/.github/workflows/validate-version.yml
@@ -25,6 +25,10 @@ jobs:
         id: get_tag
         run: |
           TAG=$(grep -E 'image:\s*ghcr.io/amazeeio/openclaw-lagoon-base:' docker-compose.yml | sed -e 's/.*openclaw-lagoon-base://' -e 's/["'\'']//g' | xargs)
+          # Unwrap the OPENCLAW_BASE_TAG override syntax: ${OPENCLAW_BASE_TAG:-vX.Y.Z} -> vX.Y.Z (validate the default)
+          case "$TAG" in
+            '${OPENCLAW_BASE_TAG:-'*'}') TAG="${TAG#\$\{OPENCLAW_BASE_TAG:-}"; TAG="${TAG%\}}" ;;
+          esac
           if [ -z "$TAG" ]; then
             echo "::error::Could not extract base image tag from docker-compose.yml"
             exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@
 services:
   openclaw-gateway:
     platform: linux/amd64
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.2-beta.2_7
+    # Tag override: set a project/environment-level Lagoon variable (build scope)
+    # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.2_7}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
## What

Makes the base image tag overridable per project or per environment:

```yaml
image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.2_7}
```

Setting a Lagoon variable `OPENCLAW_BASE_TAG` (build scope, project- or environment-level) pins that project/environment to a specific base image version. Without the variable, behaviour is identical to today — the default tag is used.

## Why

- Lets specific projects stay on (or roll back to) a chosen OpenClaw version independently of the fleet default.
- Needed for the node→basic-single migration of existing instances: pinning a migrated project to its current version separates the storage move from the version upgrade, and makes rollback deterministic (see MIGRATION notes / #27).

## Verified on a live Lagoon environment

Tested via a disposable `tagtest` branch environment on a dev pool project:
- Without the variable: build resolved `openclaw-lagoon-base:v2026.7.2-beta.2_7` (default path works, no literal `${...}` leaks).
- With environment-scoped `OPENCLAW_BASE_TAG=v2026.6.11_3` (build scope): build pulled `openclaw-lagoon-base:v2026.6.11_3`.
- Test environment, variable, and branch removed afterwards.

## Workflow updates included

- `release.yml`: yq now writes the new interpolated format (previously it would have overwritten and removed the override syntax on the next release).
- `validate-version.yml`: tag extraction unwraps `${OPENCLAW_BASE_TAG:-...}` and validates the default tag.