### PR TITLE
Release: Update to v2026.7.2-beta.4_3 + weekly release check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version of openclaw-lagoon-base to release (e.g., v2026.4.11_2)'
-        required: true
+        description: 'Version of openclaw-lagoon-base to release (e.g., v2026.4.11_2). Leave empty to use the latest upstream tag.'
+        required: false
         type: string
+  schedule:
+    # Weekly check for new openclaw-lagoon-base tags; opens a release PR when
+    # the latest upstream tag is newer than the pinned default. Merging stays manual.
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: write
@@ -19,43 +23,56 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Fetch available tags to validate
+      - name: Resolve target version
+        id: resolve
         run: |
           echo "Fetching tags from amazeeio/openclaw-lagoon-base..."
-          # Fetch recent tags using GitHub API
           TAGS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/amazeeio/openclaw-lagoon-base/tags | jq -r '.[].name' || true)
-          
-          if [ -n "$TAGS" ]; then
-            echo "Available versions in openclaw-lagoon-base:"
-            echo "$TAGS"
-            
-            if echo "$TAGS" | grep -qxF "${{ github.event.inputs.version }}"; then
-              echo "✓ Version ${{ github.event.inputs.version }} is a valid tag in openclaw-lagoon-base."
-            else
-              echo "::warning::Version ${{ github.event.inputs.version }} was not found in the recent tags list of openclaw-lagoon-base. Proceeding anyway..."
+
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            # ponytail: sort -V ranks a bare vX.Y.Z below vX.Y.Z-beta.*, but upstream
+            # stable tags always carry a _N suffix (v2026.7.1_2), which sorts above betas.
+            VERSION=$(echo "$TAGS" | sort -V | tail -1)
+            if [ -z "$VERSION" ]; then
+              echo "::error::Could not determine latest tag from openclaw-lagoon-base."
+              exit 1
             fi
-          else
-            echo "Unable to fetch tags from openclaw-lagoon-base (rate limit or access issue). Proceeding with user input."
+            echo "Latest upstream tag: $VERSION"
+          elif [ -n "$TAGS" ] && ! echo "$TAGS" | grep -qxF "$VERSION"; then
+            echo "::warning::Version $VERSION was not found in the recent tags list of openclaw-lagoon-base. Proceeding anyway..."
           fi
 
+          CURRENT=$(grep -oE 'OPENCLAW_BASE_TAG:-[^}]+' docker-compose.yml | cut -d- -f2-)
+          echo "Currently pinned: $CURRENT"
+          if [ "$VERSION" = "$CURRENT" ]; then
+            echo "Already on $VERSION — nothing to release."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Update docker-compose.yml
+        if: steps.resolve.outputs.changed == 'true'
         run: |
           # Use yq to update the default image tag for the openclaw-gateway service,
           # preserving the OPENCLAW_BASE_TAG per-project override syntax.
-          yq -i '.services.openclaw-gateway.image = "ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-${{ github.event.inputs.version }}}"' docker-compose.yml
+          yq -i '.services.openclaw-gateway.image = "ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-${{ steps.resolve.outputs.version }}}"' docker-compose.yml
 
       - name: Create Pull Request
+        if: steps.resolve.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "release: update openclaw-lagoon-base to ${{ github.event.inputs.version }}"
-          branch: "release/update-to-${{ github.event.inputs.version }}"
-          title: "Release: Update to ${{ github.event.inputs.version }}"
+          commit-message: "release: update openclaw-lagoon-base to ${{ steps.resolve.outputs.version }}"
+          branch: "release/update-to-${{ steps.resolve.outputs.version }}"
+          title: "Release: Update to ${{ steps.resolve.outputs.version }}"
           body: |
-            This Pull Request updates the base image version of `openclaw-gateway` to `${{ github.event.inputs.version }}` in `docker-compose.yml`.
-            
-            - **Target Version:** `${{ github.event.inputs.version }}`
-            
+            This Pull Request updates the base image version of `openclaw-gateway` to `${{ steps.resolve.outputs.version }}` in `docker-compose.yml`.
+
+            - **Target Version:** `${{ steps.resolve.outputs.version }}`
+
             Please review the changes and merge to deploy.
           delete-branch: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.2_7}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_3}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Updates the `openclaw-gateway` base image default to `v2026.7.2-beta.4_3` in `docker-compose.yml` (per-project `OPENCLAW_BASE_TAG` override preserved).

Skips beta.4_1/4_2 — beta.4_3 includes the runtime-version gating for the config keys beta.4's strict validation rejects (`dangerouslyDisableDeviceAuth`, reshaped `compaction`, `memorySearch`), avoiding the boot crash loop.

Also adds a weekly cron (Mon 06:00 UTC) to `release.yml` that compares the latest upstream tag against the pinned default and opens a release PR when newer. Merging stays manual; manual dispatch still works with the version input now optional (empty = latest).

Note: merging triggers `lagoon-deploy.yml` for the projects in `LAGOON_DEPLOY_PROJECTS`.