### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.4_4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_3}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_4}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Rolls out base image v2026.7.2-beta.4_4, which fixes fleet-wide deploy failures: the gateway's startup plugin verification found configured channel plugins missing from the volume (background seeding raced gateway start, made worse by a version-compare bug that re-seeded every boot) and fell back to installing clawhub's floating beta tag, which now requires a newer plugin API than the pinned runtime — so the gateway refused readiness and rollouts exceeded their progress deadline.

Base image changes (amazeeio/openclaw-lagoon-base@9c11990):
- Seed default channel plugins synchronously before the gateway starts; only npm-based extras remain background.
- Keep the prerelease suffix when comparing OpenClaw versions, so steady-state boots no longer re-run doctor --fix and re-copy all plugins.