### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.4_5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_4}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_5}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Follow-up to #32: the beta.4_x images shipped /lagoon/seed-openclaw as 0700 root:root (the build-time openclaw CLI hardens its HOME), so runtime uid 10000 never saw the baked plugin seed — fresh instances got zero seeded plugins and installed all channel plugins from clawhub at startup, which now hard-fails for whatsapp (plugin API >= beta.7 vs beta.4 runtime) and bricks gateway readiness.

v2026.7.2-beta.4_5 makes the seed dir world-readable (chmod -R a+rX on the whole seed dir, not just npm/) and removes stray build-time config backups from it. Verified: seed visible as uid 10000 in the published image.