### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.4_6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_5}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_6}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Follow-up to #33: the boot script's memorySearch remote override wrote the legacy agents.defaults.memorySearch key unconditionally, after the era scrub — beta.4+ gateways refuse to start ('Unrecognized key') on any instance whose amazee.ai backend exposes an embeddings model. v2026.7.2-beta.4_6 gates the write on the runtime schema era (memory.search on beta.4+). Audited for other ungated post-scrub era-specific writes; this was the only one.