### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.7_1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.4_6}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_1}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Upgrades the base to OpenClaw 2026.7.2-beta.7 (npm beta dist-tag; stable 2026.7.2 is not out yet — npm latest is still 2026.7.1-2).

- Channel plugins are now seeded from the @beta builds, matched to the beta core. This restores WhatsApp (the stable 2026.7.1 plugin failed to load on beta.4+ cores) and fixes beta.7's startup state-migrations (the stable msteams plugin's migration hits a changed session-store API and blocked gateway readiness).
- gateway.mode=local is seeded fill-if-absent: beta.7 refuses to start without it; beta.4 accepts the key, so rollbacks are safe.
- Verified locally: production-entrypoint boot reaches gateway ready with all 19 plugins incl. whatsapp/msteams; a genuine beta.4-written config validates on beta.7 and vice versa (no era-gate changes needed).

Fleet instances do NOT auto-upgrade (redeploy cadence disabled) — this affects new provisions and manual deploys. Canary: amazeeio-jsmclaw.