### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.7_2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_1}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_2}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Follow-up to #35: beta.7 stores exec approvals in the state DB and blocks every agent run (ExecApprovalsMigrationRequiredError) while a legacy exec-approvals.json exists. The boot script re-created that file on every boot, so any container restart re-bricked agent runs (Slack replies, automations) while the gateway itself reported healthy.

v2026.7.2-beta.7_2 era-gates the file write (only runtimes < beta.7 get it) and migrates any leftover file via openclaw doctor --fix before the exec-policy preset runs. Verified with real-entrypoint boots: fresh volume and leftover-file volume both reach gateway ready with approvals sourced from the state DB and no legacy file present.