### PR TITLE
feat: allow per-project volume sizing via OPENCLAW_VOLUME_SIZE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,10 @@ services:
     labels:
       lagoon.type: basic-single
       lagoon.persistent: /home/.openclaw
+      # Volume size override: set a project/environment-level Lagoon variable
+      # (build scope) OPENCLAW_VOLUME_SIZE to give one project a larger volume.
+      # The default matches the basic-single service-type default, so projects
+      # without the variable keep the volume they already have. Growing an
+      # existing volume needs allowVolumeExpansion on its StorageClass, and
+      # Kubernetes never allows shrinking one back.
+      lagoon.persistent.size: ${OPENCLAW_VOLUME_SIZE:-5Gi}


### PR DESCRIPTION
Lets a single project get a larger persistent volume without forking this shared repo, the same pattern as the existing `OPENCLAW_BASE_TAG` image pin.

## Why a label reading a variable

Lagoon takes the volume size only from the `lagoon.persistent.size` label, or the service-type default when the label is absent (`basic-single` = 5Gi, build-deploy-tool `internal/servicetypes/basic.go`). There is no Lagoon variable, GraphQL field, or CLI flag that sets volume size directly (`internal/generator/services.go` reads the label, falls back to the service-type default, and errors if neither resolves).

The label can read a variable, though: `internal/lagoon/compose.go` loads docker-compose through compose-go with interpolation enabled (it never passes `loader.WithSkipInterpolation`) and sets `options.Environment` to every Lagoon environment variable. Interpolation is document-wide, not limited to `image:`.

## Fleet safety

The default is `5Gi`, which is exactly the `basic-single` service-type default this repo has relied on until now. Projects without `OPENCLAW_VOLUME_SIZE` render byte-identical output to today, so their PVCs re-apply unchanged on the next deploy.

## Usage

Set a **build**-scope variable on the project or environment, then redeploy:

```
lagoon add variable -p <project> -e <environment> -N OPENCLAW_VOLUME_SIZE -V 20Gi -S build
```

## Caveats

- Growing an existing volume requires `allowVolumeExpansion: true` on its StorageClass. Without it, `kubectl apply` rejects the size change and that project's deploy fails. Blast radius is limited to the project that sets the variable.
- Kubernetes never allows shrinking a volume, so the variable is effectively one-way. On AWS EBS a volume also cannot be modified again for about six hours after an expansion.

## Validation

Rendered with `docker compose config`, which uses the same compose-go loader as build-deploy-tool:

```
# variable unset (every other project)
lagoon.persistent.size: 5Gi
lagoon.type: basic-single
image: ghcr.io/amazeeio/openclaw-lagoon-base:v2026.7.2-beta.7_2

# OPENCLAW_VOLUME_SIZE=20Gi
lagoon.persistent.size: 20Gi
```

The image tag still resolves unchanged, confirming the new interpolation does not disturb the existing one.
