### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.7_3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_2}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_3}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Rolls out openclaw-lagoon-base v2026.7.2-beta.7_3.

## What changed

New entrypoint `70-device-auto-approve.sh`: a background loop that auto-approves pending Control UI device pairing requests. The beta.4+ runtime retired `gateway.controlUi.dangerouslyDisableDeviceAuth`, so hosted users (no SSH to run `openclaw devices approve`) were hard-locked out of the Control UI with "Device pairing required".

Pairing requests are only created after the client has already authenticated with the gateway token, so auto-approving them keeps the token as the sole credential — the same trust model the retired flag provided. Per-instance opt-out: `OPENCLAW_DEVICE_AUTO_APPROVE=false`.

Base image release: amazeeio/openclaw-lagoon-base@383a25ceb8c9 (tag v2026.7.2-beta.7_3, publish workflow green).