### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.7_4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_3}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_4}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Rolls out openclaw-lagoon-base v2026.7.2-beta.7_4.

## What changed

Product/tier knobs, all inert until the corresponding env var is set on a project:

- **Brave web_search** (`BRAVE_API_KEY`): the @openclaw/brave-plugin is now baked into the image seed; when BRAVE_API_KEY is present on the environment the boot config enables the plugin and sets tools.web.search.provider=brave. The key stays in the environment and is never written into openclaw.json.
- **Browser tool toggle** (`OPENCLAW_BROWSER_ENABLED`): when set, enforces the bundled browser plugin + browser.enabled on/off; when unset, OpenClaw defaults and user Control-UI choices stay untouched.
- **PDF size cap**: seeds agents.defaults.pdfMaxMb=16 (fill-if-absent) to match the Control UI 16 MiB per-file upload limit.

Base image release: tag v2026.7.2-beta.7_4, publish workflow green.