### PR TITLE
release: update openclaw-lagoon-base to v2026.7.2-beta.7_5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     platform: linux/amd64
     # Tag override: set a project/environment-level Lagoon variable (build scope)
     # OPENCLAW_BASE_TAG to pin a project to a specific base image version.
-    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_4}
+    image: ghcr.io/amazeeio/openclaw-lagoon-base:${OPENCLAW_BASE_TAG:-v2026.7.2-beta.7_5}
     user: "10000"
     environment:
       - AMAZEEAI_BASE_URL=${AMAZEEAI_BASE_URL:-https://llm.us103.amazee.ai}


### PR DESCRIPTION
Rolls out openclaw-lagoon-base v2026.7.2-beta.7_5.

## What changed

Ensure `models.providers.amazeeai.timeoutSeconds` (default 600, override via `AMAZEEAI_TIMEOUT_SECONDS`) survives every config writer:

- Boot (`60-amazeeai-config.sh`): fills a missing timeout even when model discovery fails or the provider entry was written by an older image.
- Daily model-refresher cron: now sets the timeout when creating/updating the provider, and heals a missing timeout even when the model list is unchanged.

Both are fill-if-absent — a value a user set themselves is never overwritten. Without this, instances whose provider entry predates 2026-07-26 (or was written by the refresher) run with the too-tight upstream LLM timeout and hosted users cannot fix it without SSH.